### PR TITLE
Use env for backend URL

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://qrmenu-app.onrender.com

--- a/frontend/src/components/AddProductToMenuModal.jsx
+++ b/frontend/src/components/AddProductToMenuModal.jsx
@@ -16,6 +16,8 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 function not(a, b) {
     return a.filter((value) => b.indexOf(value) === -1);
 }
@@ -37,11 +39,11 @@ export default function TransferListModal({ open, handleClose, selectedMenuId })
     useEffect(() => {
         // Kategorileri ve ürünleri fetch etmek
         async function fetchData() {
-            const categoriesResponse = await fetch('http://localhost:5000/api/admin/categories'); // Kategorileri fetch et
+            const categoriesResponse = await fetch(`${API_URL}/api/admin/categories`); // Kategorileri fetch et
             const categoriesData = await categoriesResponse.json();
             setCategories(categoriesData);
 
-            const productsResponse = await fetch('http://localhost:5000/api/admin/products'); // Ürünleri fetch et
+            const productsResponse = await fetch(`${API_URL}/api/admin/products`); // Ürünleri fetch et
             const productsData = await productsResponse.json();
             setProducts(productsData);
         }
@@ -59,7 +61,7 @@ export default function TransferListModal({ open, handleClose, selectedMenuId })
 
     useEffect(() => {
         const fetchSelectedMenu = async () => {
-            const response = await fetch(`http://localhost:5000/api/admin/menus/${selectedMenuId}`);
+            const response = await fetch(`${API_URL}/api/admin/menus/${selectedMenuId}`);
             const data = await response.json();
             setSelectedMenuName(data.name);
         };
@@ -74,7 +76,7 @@ export default function TransferListModal({ open, handleClose, selectedMenuId })
         const fetchMenuProducts = async () => {
             if (selectedMenuId) {
                 try {
-                    const response = await fetch(`http://localhost:5000/api/admin/menus/getRegisteredProducts/${selectedMenuId}`);
+                    const response = await fetch(`${API_URL}/api/admin/menus/getRegisteredProducts/${selectedMenuId}`);
                     const menuProducts = await response.json();
 
                     setRight(menuProducts); // Sağ tarafa menüdeki mevcut ürünleri ekle
@@ -126,7 +128,7 @@ export default function TransferListModal({ open, handleClose, selectedMenuId })
 
     const handleSave = async () => {
         // Seçilen ürünleri menüye kaydet
-        const response = await fetch('http://localhost:5000/api/admin/menus/saveProducts', {
+        const response = await fetch(`${API_URL}/api/admin/menus/saveProducts`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/src/components/Additional_Category_Table.jsx
+++ b/frontend/src/components/Additional_Category_Table.jsx
@@ -3,6 +3,8 @@ import '../css/categories.css';
 import { Table, Button } from 'antd';
 import { MinusSquareOutlined, PlusCircleOutlined, PlusOutlined,EditOutlined,DeleteTwoTone} from '@ant-design/icons';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 import ModalForm from './CategoryFormModal';
 import EditCategoryModal from './EditCategoryModal';
 const App = () => {
@@ -43,7 +45,7 @@ const columns = [
 
   const fetchCategories = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/categories');
+      const response = await fetch(`${API_URL}/api/admin/categories`);
       if (!response.ok) {
         throw new Error('Network response was not ok');
       }

--- a/frontend/src/components/BulkPriceChange.jsx
+++ b/frontend/src/components/BulkPriceChange.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Form, Select, InputNumber, Button, message, Spin } from 'antd';
 import { PercentageOutlined } from '@ant-design/icons';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const { Option } = Select;
 
 const BulkPriceChange = () => {
@@ -18,7 +20,7 @@ const BulkPriceChange = () => {
   const fetchCategories = async () => {
     setLoadingCategories(true);
     try {
-      const response = await fetch('http://localhost:5000/api/admin/categories');
+      const response = await fetch(`${API_URL}/api/admin/categories`);
       if (!response.ok) {
         throw new Error('Kategoriler alınamadı!');
       }
@@ -41,7 +43,7 @@ const BulkPriceChange = () => {
     const { categoryId, percentage } = values;
     setApplyingChanges(true);
     try {
-        const response = await fetch('http://localhost:5000/api/admin/products/bulk-update-prices', {
+        const response = await fetch(`${API_URL}/api/admin/products/bulk-update-prices`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'

--- a/frontend/src/components/Categories.jsx
+++ b/frontend/src/components/Categories.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import '../css/categories.css';
 import CategoryModal from './NewCategoryModal';
 import SubCategoryModal from './NewSubCategory';
+
+const API_URL = import.meta.env.VITE_API_URL;
 // import { color, margin, width } from '@mui/system';
 
 const Categories = () => {
@@ -18,7 +20,7 @@ const Categories = () => {
 
   const fetchCategories = async () => {
     try { 
-      const response = await fetch('http://localhost:5000/api/admin/categories', {
+      const response = await fetch(`${API_URL}/api/admin/categories`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/frontend/src/components/CategoryFormModal.jsx
+++ b/frontend/src/components/CategoryFormModal.jsx
@@ -3,6 +3,8 @@ import { Modal, Form, Input, Button, Upload, message } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import '../css/CategoryFormModal.css';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const ModalForm = ({ visible, onCancel, onOk }) => {
   const [form] = Form.useForm(); // Form kontrolü
   const [file, setFile] = useState(null); // Yüklenen dosya
@@ -30,7 +32,7 @@ const ModalForm = ({ visible, onCancel, onOk }) => {
       console.log('Gönderilen veri:', { category_name: values.name, resim: file });
 
       // Backend'e veri gönderme
-      const response = await fetch('http://localhost:5000/api/admin/categories/create', {
+      const response = await fetch(`${API_URL}/api/admin/categories/create`, {
         method: 'POST',
         body: formData,
       });

--- a/frontend/src/components/CategorySelector.jsx
+++ b/frontend/src/components/CategorySelector.jsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Select, Divider, Input, Space, Button, Form } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const { Option } = Select;
 
 const CategorySelect = () => {
@@ -13,7 +15,7 @@ const CategorySelect = () => {
   // categories prop'u değiştiğinde local state'i güncelle
   useEffect(() => {
   
-      fetch('http://localhost:5000/api/admin/categories')
+      fetch(`${API_URL}/api/admin/categories`)
         .then((response) => response.json())
         .then((data) => setCategories(data));
     
@@ -27,7 +29,7 @@ const CategorySelect = () => {
     if (name && !Categories.find(cat => cat.category_name === name)) {
       const newCategory = { text: name, value: name };
       
-      const response = await fetch('http://localhost:5000/api/admin/categories/create', {
+      const response = await fetch(`${API_URL}/api/admin/categories/create`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/EditCategoryModal.jsx
+++ b/frontend/src/components/EditCategoryModal.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Modal, Form, Input, Upload, message } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const EditCategoryModal = ({ visible, onCancel, onOk, category }) => {
   const [form] = Form.useForm();
   const [file, setFile] = useState(null); // Yeni dosya yükleme
@@ -36,7 +38,7 @@ const EditCategoryModal = ({ visible, onCancel, onOk, category }) => {
 
       formData.append('category_id', category.id); // Kategori ID'sini ekle
 
-      const response = await fetch(`http://localhost:5000/api/admin/categories/update/${category.id}`, {
+      const response = await fetch(`${API_URL}/api/admin/categories/update/${category.id}`, {
         method: 'PUT',
         body: formData,
       });
@@ -77,7 +79,7 @@ const EditCategoryModal = ({ visible, onCancel, onOk, category }) => {
         <Form.Item label="Mevcut Resim">
           {previewImage ? (
             <img
-              src={`http://localhost:5000/images/${previewImage}`} // Backend'den gelen resim yolu
+              src={`${API_URL}/images/${previewImage}`} // Backend'den gelen resim yolu
               alt="Mevcut Resim"
               style={{ width: '50%', marginBottom: '10px' }}
             />

--- a/frontend/src/components/EditModal.jsx
+++ b/frontend/src/components/EditModal.jsx
@@ -3,6 +3,8 @@ import { Modal, Form, Input, Button, Upload, message, InputNumber, Col, Row, Sel
 import { PlusOutlined } from '@ant-design/icons';
 import CategorySelector from './CategorySelector';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const EditModal = ({ visible, onCancel, onOk, record }) => {
   const [form] = Form.useForm();
   const [file, setFile] = useState(null);
@@ -26,9 +28,9 @@ const EditModal = ({ visible, onCancel, onOk, record }) => {
       
       // Eğer resim varsa göster
       if (record.image_url) {
-        // URL'den localhost kısmını kaldır çünkü zaten tam URL geliyor
-        const imageUrl = record.image_url.replace('http://localhost:5000', '');
-        setFile({ preview: `http://localhost:5000${imageUrl}` });
+        // URL'den ana sunucu kısmını kaldır çünkü zaten tam URL geliyor
+        const imageUrl = record.image_url.replace(`${API_URL}`, '');
+        setFile({ preview: `${API_URL}${imageUrl}` });
       }
     }
   }, [record, form]);
@@ -67,7 +69,7 @@ const EditModal = ({ visible, onCancel, onOk, record }) => {
       formData.append('status', status === 'true');
       formData.append('showcase', showcase === 'true');
 
-      const response = await fetch('http://localhost:5000/api/admin/products/update', {
+      const response = await fetch(`${API_URL}/api/admin/products/update`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/ExcelImportButton.jsx
+++ b/frontend/src/components/ExcelImportButton.jsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { Button, Upload, message, Tooltip } from 'antd';
 import { UploadOutlined, InfoCircleOutlined } from '@ant-design/icons';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const ExcelImportButton = ({ onSuccess }) => {
   const handleUpload = async ({ file }) => {
     const formData = new FormData();
     formData.append('excel', file);
 
     try {
-      const response = await fetch('http://localhost:5000/api/admin/uploadExcel', {
+      const response = await fetch(`${API_URL}/api/admin/uploadExcel`, {
         method: 'POST',
         body: formData,
       });

--- a/frontend/src/components/FoodMenus.jsx
+++ b/frontend/src/components/FoodMenus.jsx
@@ -3,6 +3,8 @@ import '../css/FoodMenus.css';
 import MenuModal from './MenuCreateModal';
 import AddProductModal from './AddProductToMenuModal';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 
 
 const Menus = () => {
@@ -32,7 +34,7 @@ const handleCloseModal = () => {
 
   const fetchMenus = async () => {
     try { 
-      const response = await fetch('http://localhost:5000/api/admin/menus', {
+      const response = await fetch(`${API_URL}/api/admin/menus`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Carousel, Card, Checkbox } from 'antd';
 const { Meta } = Card;
+const API_URL = import.meta.env.VITE_API_URL;
 // import "../css/CategorySlider.css";
 
 const contentStyle = {
@@ -24,7 +25,7 @@ const App = () => {
   const [is_available, setIsAvailable] = useState(true); // Varsayılan olarak true, ürünler olup olmadığı kontrol edilecek
 
   useEffect(() => {
-    fetch("http://localhost:5000/api/admin/categories")
+    fetch(`${API_URL}/api/admin/categories`)
       .then((response) => response.json())
       .then((categories) => setCategories(categories))
       .catch((error) => console.error("Veri çekme hatası:", error));
@@ -32,7 +33,7 @@ const App = () => {
 
   const handleCategoryClick = async (category_id) => {  
     try {
-      const response = await fetch(`http://localhost:5000/api/admin/productsByCategory/${category_id}`);
+      const response = await fetch(`${API_URL}/api/admin/productsByCategory/${category_id}`);
       
       // Burada response objesini kontrol etmemiz gerek
       if (!response.ok) {
@@ -68,7 +69,7 @@ const App = () => {
                     <img
                       style={{ width: "130px", height: "80px" }}
                       alt={category.category_name}
-                      src={`http://localhost:5000/images/${category.image_url}`}
+                      src={`${API_URL}/images/${category.image_url}`}
                     />
                   ) : null
                 }
@@ -98,7 +99,7 @@ const App = () => {
                         product.image_url ? (
                           <img
                             alt={product.product_name}
-                            src={`http://localhost:5000/images/${product.image_url}`}
+                            src={`${API_URL}/images/${product.image_url}`}
                           />
                         ) : null
                       }

--- a/frontend/src/components/MenuCreateModal.jsx
+++ b/frontend/src/components/MenuCreateModal.jsx
@@ -1,5 +1,6 @@
 import React , { useEffect, useState } from 'react';
 import '../css/menuModal.css'
+const API_URL = import.meta.env.VITE_API_URL;
 const MenuCreateModal = ({ show, handleClose, handleSave }) =>{
     const [menuName, setMenuName] = useState('');
     const [error,setError] = useState('');
@@ -11,7 +12,7 @@ const MenuCreateModal = ({ show, handleClose, handleSave }) =>{
     const handleSubmit = async(e) => {
       e.preventDefault();
       try {
-        const response = await fetch('http://localhost:5000/api/admin/menus/create', {
+        const response = await fetch(`${API_URL}/api/admin/menus/create`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/frontend/src/components/NewCategoryModal.jsx
+++ b/frontend/src/components/NewCategoryModal.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const CategoryModal = ({ show, handleClose, handleSave }) => {
   const [name, setName] = useState('');
   const [error, setError] = useState('');
@@ -8,7 +10,7 @@ const CategoryModal = ({ show, handleClose, handleSave }) => {
     e.preventDefault();
     try {
       const response = await fetch(
-        'http://localhost:5000/api/admin/categories/create',
+        `${API_URL}/api/admin/categories/create`,
         {
           method: 'POST',
           headers: {

--- a/frontend/src/components/NewProductModal.jsx
+++ b/frontend/src/components/NewProductModal.jsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import CategoryModal from './NewCategoryModal';
 import '../css/productModal.css';
+const API_URL = import.meta.env.VITE_API_URL;
 const ProductModal = ({ show, handleClose, handleSave }) => {
   const [file, setFile] = useState(null); // Dosyayı saklamak için state
   const [fileName, setFileName] = useState('Dosya Seçilmedi'); // Başlangıçta "Dosya Seçilmedi" metni
@@ -22,7 +23,7 @@ const ProductModal = ({ show, handleClose, handleSave }) => {
 
   const fetchCategories = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/categories');
+      const response = await fetch(`${API_URL}/api/admin/categories`);
       if (!response.ok) {
         throw new Error('Kategorileri çekmede bir hata oluştu');
       }
@@ -46,7 +47,7 @@ const ProductModal = ({ show, handleClose, handleSave }) => {
     
     try {
       const response = await fetch(
-        'http://localhost:5000/api/admin/products/create',
+        `${API_URL}/api/admin/products/create`,
         {
           method: 'POST',
           body: formData,
@@ -72,7 +73,7 @@ const ProductModal = ({ show, handleClose, handleSave }) => {
 
   const fetchLastCategory = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/categories/last');
+      const response = await fetch(`${API_URL}/api/admin/categories/last`);
       if (!response.ok) {
         throw new Error('Kategorileri çekmede bir hata oluştu');
       }

--- a/frontend/src/components/NewSubCategory.jsx
+++ b/frontend/src/components/NewSubCategory.jsx
@@ -1,5 +1,7 @@
 import React, { useState ,useEffect} from 'react';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const SubCategoryModal = ({ show, handleClose, handleSave ,parentId }) => {
   const [name, setName] = useState('');
   const [error, setError] = useState('');
@@ -17,7 +19,7 @@ const SubCategoryModal = ({ show, handleClose, handleSave ,parentId }) => {
     e.preventDefault();
     try{
         const response = await fetch(
-            `http://localhost:5000/api/admin/categories/subs/${parentId}` ,
+            `${API_URL}/api/admin/categories/subs/${parentId}` ,
             {
                 method: 'GET',
                 headers: {
@@ -47,7 +49,7 @@ const SubCategoryModal = ({ show, handleClose, handleSave ,parentId }) => {
     e.preventDefault();
     try {
       const response = await fetch(
-        'http://localhost:5000/api/admin/categories/create-sub',
+        `${API_URL}/api/admin/categories/create-sub`,
         {
           method: 'POST',
           headers: {

--- a/frontend/src/components/PriceChange.jsx
+++ b/frontend/src/components/PriceChange.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Table, Input, Button, Form, message } from 'antd';
 import { EditOutlined, SaveOutlined, CloseOutlined } from '@ant-design/icons';
 import "../css/pricechange.css";
+
+const API_URL = import.meta.env.VITE_API_URL;
 const EditableCell = ({
   editing,
   dataIndex,
@@ -70,7 +72,7 @@ const ProductPriceTable = () => {
   // Ürünleri API'den çekme
   const fetchProducts = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/products');
+      const response = await fetch(`${API_URL}/api/admin/products`);
       if (!response.ok) {
         throw new Error('Ürünler alınamadı!');
       }
@@ -147,7 +149,7 @@ const ProductPriceTable = () => {
 
   const updateProductPrice = async (productId, newPrice) => {
     try {
-      const response = await fetch(`http://localhost:5000/api/admin/products/updatePrice`, {
+      const response = await fetch(`${API_URL}/api/admin/products/updatePrice`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/ProductFormModal.jsx
+++ b/frontend/src/components/ProductFormModal.jsx
@@ -3,6 +3,7 @@ import { Modal, Form, Input, Button, Upload, message ,InputNumber, Col,Row,Selec
 import { PlusOutlined,UploadOutlined } from '@ant-design/icons';
 import CategorySelector from './CategorySelector'
 // import '../css/CategoryFormModal.css';
+const API_URL = import.meta.env.VITE_API_URL;
 const ModalForm = ({ visible, onCancel, onOk}) => {
   const [form] = Form.useForm(); // Form kontrolü
   // const [loading, setLoading] = useState(false);
@@ -20,7 +21,7 @@ const ModalForm = ({ visible, onCancel, onOk}) => {
 
   const fetchProducts = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/products');
+      const response = await fetch(`${API_URL}/api/admin/products`);
       if (!response.ok) {
         throw new Error('Ürünler yüklenirken bir hata oluştu');
       }
@@ -83,7 +84,7 @@ const ModalForm = ({ visible, onCancel, onOk}) => {
       formData.append('showcase', showcase === 'true');
       
       // Backend'e veri gönderme
-      const response = await fetch('http://localhost:5000/api/admin/products/create', {
+      const response = await fetch(`${API_URL}/api/admin/products/create`, {
         method: 'POST',
         body: formData,
       });

--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -8,6 +8,8 @@ import { Select,Input } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
 import { Dropdown, Space } from 'antd';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 export const ProductContext = createContext();
 
 
@@ -104,7 +106,7 @@ useEffect(() => {
 
   const fetchProducts = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/products');
+      const response = await fetch(`${API_URL}/api/admin/products`);
       if (!response.ok) {
         throw new Error('Verileri çekmede bir hata oluştu');
       }
@@ -118,7 +120,7 @@ useEffect(() => {
 
   // const fetchMenus = async () => {
   //   try {
-  //     const response = await fetch('http://localhost:5000/api/admin/menus');
+  //     const response = await fetch(`${API_URL}/api/admin/menus`);
   //     if (!response.ok) {
   //       throw new Error('Verileri çekmede bir hata oluştu');
   //     }

--- a/frontend/src/components/Product_Table.jsx
+++ b/frontend/src/components/Product_Table.jsx
@@ -6,6 +6,8 @@ import ExcelImportButton from './ExcelImportButton';
 import EditFormModal from './EditModal';
 import '../css/tableSizeManager.css';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 
 const Product_Table = () => {
   const [data, setData] = useState([]);  // Verileri burada tutacağız
@@ -24,14 +26,14 @@ const Product_Table = () => {
   const fetchData = async () => {
 
       try {
-        const response = await fetch('http://localhost:5000/api/admin/products');
+        const response = await fetch(`${API_URL}/api/admin/products`);
         if (!response.ok) {
           throw new Error('Verileri çekmede bir hata oluştu');
         }
         const datas = await response.json();
 
         const formattedData = datas.map((item, index) => {
-          const imageUrl = item.image_url ? `http://localhost:5000/images/${item.image_url}` : null;
+          const imageUrl = item.image_url ? `${API_URL}/images/${item.image_url}` : null;
 
           return {
             key: index, 
@@ -77,7 +79,7 @@ const Product_Table = () => {
   const handleShowcaseToggle = async (productId, newShowcaseState) => {
     
     try{
-    const response =await fetch(`http://localhost:5000/api/admin/products/updateShowcase/${productId}`, {
+    const response =await fetch(`${API_URL}/api/admin/products/updateShowcase/${productId}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -102,7 +104,7 @@ const Product_Table = () => {
   const handleStatusToggle = async (productId, newStatus) => {
   
     try{
-      const response =await fetch(`http://localhost:5000/api/admin/products/updateStatus/${productId}`, {
+      const response =await fetch(`${API_URL}/api/admin/products/updateStatus/${productId}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -336,7 +338,7 @@ const UploadImageButton = ({ productId ,onUploadSuccess}) => {
     
 
     try {
-      const response = await fetch('http://localhost:5000/api/admin/products/updateImageUrl', {
+      const response = await fetch(`${API_URL}/api/admin/products/updateImageUrl`, {
         method: 'POST',  // "UPDATE" yerine "POST" kullanıyoruz
         body: formData,
       });

--- a/frontend/src/components/Sort2.jsx
+++ b/frontend/src/components/Sort2.jsx
@@ -6,6 +6,8 @@ import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } 
 import { CSS } from '@dnd-kit/utilities';
 import { Button, Table } from 'antd';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const RowContext = React.createContext({});
 
 const DragHandle = () => {
@@ -80,7 +82,7 @@ const DragAndDropTable = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/productsBySiraid');
+      const response = await fetch(`${API_URL}/api/admin/productsBySiraid`);
       if (!response.ok) throw new Error('Network response was not ok');
       const result = await response.json();
       setData(result);
@@ -105,7 +107,7 @@ const DragAndDropTable = () => {
 
   const handleSave = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/admin/products/yeniSira', {
+      const response = await fetch(`${API_URL}/api/admin/products/yeniSira`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ products: data }),


### PR DESCRIPTION
## Summary
- add `.env` with backend URL
- replace localhost API calls in frontend components with env variable

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6854712ad8248321a64de5cb5c6fe17e